### PR TITLE
BUG-1724 : ulkoiset-rajapinnat -sovellus jää jumiin

### DIFF
--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -117,8 +117,8 @@
         luokka (get latest-opiskelu "luokka")
         oppilaitos (get latest-opiskelu "oppilaitosOid")
         latest-suoritus (find-latest-suoritus (filter #(= oppilaitos (get % "myontaja")) suoritukset))
-        paattovuosi (t/year (parse-valmistuminen latest-suoritus))
-        opetuskieli (get latest-suoritus "suoritusKieli")
+        paattovuosi (if latest-suoritus (t/year (parse-valmistuminen latest-suoritus)) nil)
+        opetuskieli (if latest-suoritus (get latest-suoritus "suoritusKieli") nil)
         oppilaitoskoodi (get-value-if-not-nil "oppilaitosKoodi" (find-first-matching "oid" oppilaitos organisaatiot))]
     {:paattoluokka luokka
      :perusopetuksen_paattovuosi paattovuosi

--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.core.async :refer [<! close! go go-loop chan timeout >! alt! alts! promise-chan]]
             [clojure.tools.logging :as log]
-            [full.async :refer :all]
+            [full.async :refer [<? engulf alts?]]
             [schema.core :as s]
             [ulkoiset-rajapinnat.organisaatio :refer [fetch-organisations-in-batch-channel]]
             [ulkoiset-rajapinnat.onr :refer :all]

--- a/src/ulkoiset_rajapinnat/haku.clj
+++ b/src/ulkoiset_rajapinnat/haku.clj
@@ -63,10 +63,10 @@
           hakutapa (<?? (koodisto-as-channel "hakutapa"))
           haunkohdejoukko (<?? (koodisto-as-channel "haunkohdejoukko"))
           haunkohdejoukontarkenne (<?? (koodisto-as-channel "haunkohdejoukontarkenne"))
-          haku (<?? (fetch-haku vuosi))
+          hakus (<?? (fetch-haku vuosi))
           ]
       (let [haku-converter (partial transform-haku kieli kausi hakutyyppi hakutapa haunkohdejoukko haunkohdejoukontarkenne)
-            converted-hakus (map haku-converter haku)
+            converted-hakus (map haku-converter hakus)
             json (to-json converted-hakus)]
             (-> channel
                   (status 200)

--- a/src/ulkoiset_rajapinnat/haku.clj
+++ b/src/ulkoiset_rajapinnat/haku.clj
@@ -27,8 +27,7 @@
 
 (defn haku-to-names [kieli haku]
   (let [nimet (filter #((comp not str/blank?) (last %)) (haku "nimi"))
-        koodisto_kieli_nimet (map (fn [e] [(get kieli (first e)) (last e)]) nimet)
-        ]
+        koodisto_kieli_nimet (map (fn [e] [(get kieli (first e)) (last e)]) nimet)]
     (into (sorted-map) koodisto_kieli_nimet)))
 
 (defn transform-haku [kieli kausi hakutyyppi hakutapa haunkohdejoukko haunkohdejoukontarkenne haku]
@@ -68,8 +67,7 @@
           ]
       (let [haku-converter (partial transform-haku kieli kausi hakutyyppi hakutapa haunkohdejoukko haunkohdejoukontarkenne)
             converted-hakus (map haku-converter haku)
-            json (to-json converted-hakus)
-            ]
+            json (to-json converted-hakus)]
             (-> channel
                   (status 200)
                   (body-and-close json))))

--- a/src/ulkoiset_rajapinnat/haku.clj
+++ b/src/ulkoiset_rajapinnat/haku.clj
@@ -58,23 +58,16 @@
 (defn haku-resource [vuosi request user channel]
   (go
     (try
-    (let [kieli (<<?? (koodisto-as-channel "kieli"))
-          kausi (<<?? (koodisto-as-channel "kausi"))
-          hakutyyppi (<<?? (koodisto-as-channel "hakutyyppi"))
-          hakutapa (<<?? (koodisto-as-channel "hakutapa"))
-          haunkohdejoukko (<<?? (koodisto-as-channel "haunkohdejoukko"))
-          haunkohdejoukontarkenne (<<?? (koodisto-as-channel "haunkohdejoukontarkenne"))
-          haku (<<?? (fetch-haku vuosi))
+    (let [kieli (<?? (koodisto-as-channel "kieli"))
+          kausi (<?? (koodisto-as-channel "kausi"))
+          hakutyyppi (<?? (koodisto-as-channel "hakutyyppi"))
+          hakutapa (<?? (koodisto-as-channel "hakutapa"))
+          haunkohdejoukko (<?? (koodisto-as-channel "haunkohdejoukko"))
+          haunkohdejoukontarkenne (<?? (koodisto-as-channel "haunkohdejoukontarkenne"))
+          haku (<?? (fetch-haku vuosi))
           ]
-      (let [haku-converter (apply partial
-                                  (into [transform-haku]
-                                        (map first [kieli
-                                         kausi
-                                         hakutyyppi
-                                         hakutapa
-                                         haunkohdejoukko
-                                         haunkohdejoukontarkenne])))
-            converted-hakus (map haku-converter (first haku))
+      (let [haku-converter (partial transform-haku kieli kausi hakutyyppi hakutapa haunkohdejoukko haunkohdejoukontarkenne)
+            converted-hakus (map haku-converter haku)
             json (to-json converted-hakus)
             ]
             (-> channel

--- a/src/ulkoiset_rajapinnat/haku.clj
+++ b/src/ulkoiset_rajapinnat/haku.clj
@@ -1,5 +1,5 @@
 (ns ulkoiset-rajapinnat.haku
-  (:require [full.async :refer :all]
+  (:require [full.async :refer [<?]]
             [clojure.string :as str]
             [clojure.core.async :refer [go]]
             [clojure.tools.logging :as log]
@@ -57,13 +57,13 @@
 (defn haku-resource [vuosi request user channel]
   (go
     (try
-    (let [kieli (<?? (koodisto-as-channel "kieli"))
-          kausi (<?? (koodisto-as-channel "kausi"))
-          hakutyyppi (<?? (koodisto-as-channel "hakutyyppi"))
-          hakutapa (<?? (koodisto-as-channel "hakutapa"))
-          haunkohdejoukko (<?? (koodisto-as-channel "haunkohdejoukko"))
-          haunkohdejoukontarkenne (<?? (koodisto-as-channel "haunkohdejoukontarkenne"))
-          hakus (<?? (fetch-haku vuosi))
+    (let [kieli (<? (koodisto-as-channel "kieli"))
+          kausi (<? (koodisto-as-channel "kausi"))
+          hakutyyppi (<? (koodisto-as-channel "hakutyyppi"))
+          hakutapa (<? (koodisto-as-channel "hakutapa"))
+          haunkohdejoukko (<? (koodisto-as-channel "haunkohdejoukko"))
+          haunkohdejoukontarkenne (<? (koodisto-as-channel "haunkohdejoukontarkenne"))
+          hakus (<? (fetch-haku vuosi))
           ]
       (let [haku-converter (partial transform-haku kieli kausi hakutyyppi hakutapa haunkohdejoukko haunkohdejoukontarkenne)
             converted-hakus (map haku-converter hakus)

--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -3,7 +3,7 @@
   (:require [org.httpkit.client :as http]
             [cheshire.core :refer :all]
             [full.async :refer :all]
-            [clojure.core.async :refer [>!! promise-chan >! go put! close!]]
+            [clojure.core.async :refer [>! promise-chan >! go put! close!]]
             [clojure.tools.logging :as log]
             [org.httpkit.server :refer :all])
   (:import (clojure.lang IExceptionInfo)))
@@ -59,8 +59,10 @@
 
 (defn- call-as-channel [method url options mapper]
   (let [p (promise-chan)]
-      (method url options #(do (>!! p (transform-response mapper %))
-                               (close! p)))
+    (method url options
+      #(go
+        (do (>! p (transform-response mapper %))
+          (close! p))))
     p))
 
 (defn get-as-channel

--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -59,7 +59,7 @@
 
 (defn- call-as-channel [method url options mapper]
   (let [p (promise-chan)]
-    (method url options
+    (method url (assoc-in options [:headers "Caller-Id"] "fi.opintopolku.ulkoiset-rajapinnat")
       #(go
         (do (>! p (transform-response mapper %))
           (close! p))))


### PR DESCRIPTION
Ks. https://jira.oph.ware.fi/jira/browse/BUG-1724

Monet ulkoiset-rajapinnat -sovelluksen toiminnot käyttivät core.async -channelien käsittelyyn blokkaavia operaattoreita. Tämä aiheutti sen, että jos tällaisia operaatioita oli menossa kerrallaan core.asyncin käytössä olevien threadien määrä tai enemmän, syntyi deadlock, josta ei päässyt eteenpäin.

Oletuksena threadien määrä on sama kuin koneen corejen määrä, joten esimerkiksi omalla koneellani 7 rinnakkaista pyyntöä meni aina ongelmitta läpi, mutta 8 jumittui säännöllisesti.

Samalla löytyi pari pienempää korjattua asiaa
- hakemusrajapinta kaatui, jos viimeisintä suoritusta ei löytynyt ( https://github.com/Opetushallitus/ulkoiset-rajapinnat/commit/2b13292cc3dc8156490e66bd5bfd5660bb1e3943  )
- `Caller-Id`-headeri puuttui