### PR TITLE
BUG-1819 - Access log to contain correct status code and error message

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,5 +53,6 @@
                                   [tempfile "0.2.0"]
                                   [de.flapdoodle.embed/de.flapdoodle.embed.mongo "2.0.0"]
                                   ;[com.github.fakemongo/fongo "2.1.0"]
-                                  [ring/ring-mock "0.3.1"]]}})
+                                  [ring/ring-mock "0.3.1"]
+                                  [audiogum/picomock "0.1.11"]]}})
 

--- a/src/ulkoiset_rajapinnat/utils/headers.clj
+++ b/src/ulkoiset_rajapinnat/utils/headers.clj
@@ -42,26 +42,34 @@
 (def custom-time-formatter (f/with-zone (f/formatter "yyyy-MM-dd HH:mm:ss")
                                         (t/default-time-zone)))
 
-(defn parse-request-headers [request closed-by start-time]
-  (let [duration (- (System/currentTimeMillis) start-time)
-        time-now (t/now)
-        time-now-local (f/unparse custom-time-formatter time-now)
-        method (get-method-from-request request)
-        path-info (request :uri)
-        query-string (request :query-string)
-        headers (request :headers)]
-    {:user-agent    (user-agent-from-request request)
-     :remote-addr   (remote-addr-from-request request)
-     :x-real-ip (optional-value-or-dash "x-real-ip" headers)
-     :x-forwarded-for (optional-value-or-dash "x-forwarded-for" headers)
-     :timestamp     time-now
-     :timestamp-local time-now-local
-     :customer      "OPH"
-     :service       "ulkoiset-rajapinnat"
-     :closed-by     closed-by
-     :request       (str method " " path-info "?" query-string)
-     :requestMethod method
-     :responseTime  (str duration)
-     :caller-id (optional-value-or-dash "caller-id" headers)
-     :clientSubSystemCode (optional-value-or-dash "clientsubsystemcode" headers)
-     }))
+(defn parse-request-headers
+
+  ([request response-code start-time]
+   (parse-request-headers request response-code start-time nil))
+
+  ([request response-code start-time error-message]
+   (let [duration (- (System/currentTimeMillis) start-time)
+         time-now (t/now)
+         time-now-local (f/unparse custom-time-formatter time-now)
+         method (get-method-from-request request)
+         path-info (request :uri)
+         query-string (request :query-string)
+         headers (request :headers)
+         access-log-entry {:user-agent    (user-agent-from-request request)
+                           :remote-addr   (remote-addr-from-request request)
+                           :x-real-ip (optional-value-or-dash "x-real-ip" headers)
+                           :x-forwarded-for (optional-value-or-dash "x-forwarded-for" headers)
+                           :timestamp     time-now
+                           :timestamp-local time-now-local
+                           :customer      "OPH"
+                           :service       "ulkoiset-rajapinnat"
+                           :response-code response-code
+                           :request       (str method " " path-info "?" query-string)
+                           :requestMethod method
+                           :responseTime  (str duration)
+                           :caller-id (optional-value-or-dash "caller-id" headers)
+                           :clientSubSystemCode (optional-value-or-dash "clientsubsystemcode" headers)}]
+     (if error-message
+       (assoc access-log-entry :error-message error-message)
+       access-log-entry)))
+)

--- a/test/ulkoiset_rajapinnat/test_utils.clj
+++ b/test/ulkoiset_rajapinnat/test_utils.clj
@@ -26,7 +26,6 @@
 (def default-write-access-log write-access-log)
 
 (def mock-write-access-log (fn [start-time response-code request error-message]
-                             (println (str "ACCESS LOG CODE " response-code))
                              (default-write-access-log start-time response-code request error-message)))
 
 (defn assert-access-log-write [access-log-mock expected-status expected-error-message]


### PR DESCRIPTION
Part of this fix is to write to access log explicitly. 

Previously, writing to access log was happening within
on-close handler for the channel. The problem was that
the on-close handler does not have enough information
about response code and error message. Now the implementation
is modified so that every service explicetly writes to
access log.

Additionally, all unit tests verify that the correct status
code and error message are written to access log, and that
there is exactly one record in access log per one invocation of
an API service. For this, utilized is `picomock` mocking library. 