### PR TITLE
BUG-1826 *-for-haku services to return 404 if haku is not found

### DIFF
--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -268,10 +268,11 @@
                    (log-to-access-log 500 (.getMessage e))))
                (finally
                  (close-channel))))
-           (do (status channel 404)
-               (body channel (to-json {:error (format "Haku %s not found" haku-oid)}))
-               (close channel)
-               (log-to-access-log 404 (format "Haku %s not found" haku-oid)))))
+           (let [message (format "Haku %s not found" haku-oid)]
+             (status channel 404)
+             (body channel (to-json {:error message}))
+             (close channel)
+             (log-to-access-log 404 message))))
      (catch Throwable e (let [error-message (.getMessage e)
                               is-illegal-argument (or (instance? IllegalArgumentException e)
                                                       (instance? IllegalArgumentException (.getCause e)))

--- a/test/ulkoiset_rajapinnat/haku_test.clj
+++ b/test/ulkoiset_rajapinnat/haku_test.clj
@@ -71,7 +71,7 @@
             (let [response (client/get (api-call "/api/haku-for-year/2017"))]
               (is (= false true) "should not reach this line"))
             (catch Exception e
-              (assert-access-log-write access-log-mock 500 "Unexpected error from url http://fake.virkailija.opintopolku.fi/koodisto-service/rest/codeelement/codes/kieli/1 -> fake.virkailija.opintopolku.fi: nodename nor servname provided, or not known")
+              (assert-access-log-write access-log-mock 500 "Unexpected error from url http://fake.virkailija.opintopolku.fi/koodisto-service/rest/codeelement/codes/kieli/1")
               (is (= 500 ((ex-data e) :status)))
               (is (re-find #"Unexpected error" ((ex-data e) :body))))))))
 

--- a/test/ulkoiset_rajapinnat/hakukohde_test.clj
+++ b/test/ulkoiset_rajapinnat/hakukohde_test.clj
@@ -34,6 +34,8 @@
   (log/info (str "Mocking url " url))
   (def response (partial channel-response transform url))
   (case url
+    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.25191045126" (response 200 "{\"result\": \"dummy\"}")
+    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.9999009999" (response 200 "{\"result\": \"dummy\"}")
     "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.25191045126/hakukohdeTulos?hakukohdeTilas=JULKAISTU&count=-1" (response 200 hakukohde-tulos-json)
     "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.9999009999/hakukohdeTulos?hakukohdeTilas=JULKAISTU&count=-1" (response 200 hakukohde-tulos-empty-json)
     "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/koulutus/search?hakuOid=1.2.246.562.29.25191045126" (response 200 koulutus-json)
@@ -46,10 +48,19 @@
     "http://fake.virkailija.opintopolku.fi/organisaatio-service/rest/organisaatio/v3/findbyoids" (response 200 organisaatio-json)
     (response 404 "[]")))
 
+(defn mock-not-found-http [url options transform]
+  (log/info (str "Mocking url " url))
+  (def response (partial channel-response transform url))
+  (case url
+    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/INVALID_HAKU" (response 200 "{}")
+    (response 404 "[]")))
+
+
 (defn mock-http-stuck [url options transform]
   (log/info (str "Mocking url for tilastokeskus failed case " url))
   (def response (partial channel-response transform url))
   (case url
+    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.25191045126" (response 200 "{\"result\": \"dummy\"}")
     "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.25191045126/hakukohdeTulos?hakukohdeTilas=JULKAISTU&count=-1" (response 200 hakukohde-tulos-json)
     "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/koulutus/search?hakuOid=1.2.246.562.29.25191045126" (response 200 koulutus-json)
     "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/hakukohde/tilastokeskus" (response 500 tilastokeskus-json)
@@ -78,6 +89,21 @@
           (def expected (parse-string (resource "test/resources/hakukohde/result-empty.json")))
           (def difference (diff expected body))
           (is (= [nil nil expected] difference) difference)))))
+
+  (testing "return status 404 if haku is not found"
+    (let [access-log-mock (pico/mock mock-write-access-log)]
+      (with-redefs [check-ticket-is-valid-and-user-has-required-roles (fn [& _] (go fake-user))
+                    oppijat-batch-size 2
+                    valintapisteet-batch-size 2
+                    http/get (fn [url options transform] (mock-not-found-http url options transform))
+                    fetch-jsessionid-channel (fn [a b c d] (mock-channel "FAKEJSESSIONID"))
+                    write-access-log access-log-mock]
+        (try
+          (let [response (client/get (api-call "/api/hakukohde-for-haku/INVALID_HAKU"))]
+            (is (= false true)))
+          (catch Exception e
+            (assert-access-log-write access-log-mock 404 "Haku INVALID_HAKU not found")
+            (is (= 404 ((ex-data e) :status))))))))
 
   (testing "return status 500 if POST request to tilastokeskus fails with status 500 (don't get stuck)"
     (let [access-log-mock (pico/mock mock-write-access-log)]
@@ -113,4 +139,7 @@
           (def expected (parse-string (resource "test/resources/hakukohde/result.json")))
           (def difference (diff expected body))
           (is (= [nil nil expected] difference) difference)
-          (assert-access-log-write access-log-mock 200 nil))))))
+          (assert-access-log-write access-log-mock 200 nil)))))
+
+
+  )

--- a/test/ulkoiset_rajapinnat/test_utils.clj
+++ b/test/ulkoiset_rajapinnat/test_utils.clj
@@ -31,4 +31,5 @@
 (defn assert-access-log-write [access-log-mock expected-status expected-error-message]
   (is (= 1 (pico/mock-calls access-log-mock)))
   (is (= expected-status (-> (pico/mock-args access-log-mock) first second)))
-  (is (= expected-error-message (nth (first (pico/mock-args access-log-mock)) 3))))
+  (when expected-error-message
+    (is (re-find (re-pattern expected-error-message) (nth (first (pico/mock-args access-log-mock)) 3)))))

--- a/test/ulkoiset_rajapinnat/test_utils.clj
+++ b/test/ulkoiset_rajapinnat/test_utils.clj
@@ -1,6 +1,7 @@
 (ns ulkoiset-rajapinnat.test_utils
   (:require [clojure.core.async :refer [promise-chan put! >!! close! go]]
             [clojure.test :refer [is]]
+            [clj-log4j2.core :as log]
             [ulkoiset-rajapinnat.utils.access :refer [write-access-log]]
             [picomock.core :as pico])
   (:import (java.io ByteArrayInputStream)))
@@ -33,3 +34,11 @@
   (is (= expected-status (-> (pico/mock-args access-log-mock) first second)))
   (when expected-error-message
     (is (re-find (re-pattern expected-error-message) (nth (first (pico/mock-args access-log-mock)) 3)))))
+
+(defn mock-haku-not-found-http [url transform]
+  (log/info (str "Mocking url " url))
+  (def response (partial channel-response transform url))
+  (case url
+    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/INVALID_HAKU" (response 200 "{}")
+    (response 404 "[]")))
+

--- a/test/ulkoiset_rajapinnat/vastaanotto_test.clj
+++ b/test/ulkoiset_rajapinnat/vastaanotto_test.clj
@@ -42,7 +42,7 @@
       (case url
         "http://fake.internal.virkailija.opintopolku.fi/valinta-tulos-service/haku/streaming/1.2.246.562.29.25191045126/sijoitteluajo/latest/hakemukset?vainMerkitsevaJono=true" (response 200 vastaanotot-json)
         "http://fake.virkailija.opintopolku.fi/valintaperusteet-service/resources/hakukohde/avaimet" (response 200 (if use-empty-avaimet avaimet-empty-json avaimet-json))
-        "http://fake.virkailija.opintopolku.fi/suoritusrekisteri/rest/v1/oppijat/?ensikertalaisuudet=false&haku=1.2.246.562.29.25191045126" (response 200 (oppijat-chunk (options :body)))
+        "http://fake.internal.virkailija.opintopolku.fi/suoritusrekisteri/rest/v1/oppijat/?ensikertalaisuudet=false&haku=1.2.246.562.29.25191045126" (response 200 (oppijat-chunk (options :body)))
         "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.25191045126" (response 200 haku-json)
         "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/hakukohde/tilastokeskus" (response 200 tilastokeskus-json)
         (response 404 "[]")))))


### PR DESCRIPTION
Affected services: 

- hakukohde-for-haku
- vastaanotto-for-haku
- hakemus-for-haku (done in #14)

Additionally, changed some of existing test cases to work
correctly with changes done for #17 