### PR TITLE
BUG-1863 :  vastaanotto for haku -korjaukset

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ or
 
 `lein run ulkoisetrajapinnat-properties=../my.edn`
 
+or run in REPL
+
+`(ulkoiset-rajapinnat.core/-main "ulkoisetrajapinnat-properties=my.edn")`
+
 ## CAS with Node.js Example
 
 `npm install --save cheerio request`

--- a/lein
+++ b/lein
@@ -4,7 +4,7 @@
 # somewhere on your $PATH, like ~/bin. The rest of Leiningen will be
 # installed upon first run into the ~/.lein/self-installs directory.
 
-export LEIN_VERSION="2.5.1"
+export LEIN_VERSION="2.8.1"
 
 case $LEIN_VERSION in
     *SNAPSHOT) SNAPSHOT="YES" ;;

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  ["oph-snapshots" "https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local"]
                  ["ext-snapshots" "https://artifactory.opintopolku.fi/artifactory/ext-snapshot-local"]]
   :dependencies [[javax.servlet/javax.servlet-api "3.1.0"]
-                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.3.443"]
                  [fi.vm.sade/auditlogger "8.0.0-SNAPSHOT"]
                  [environ "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -49,7 +49,7 @@
             [me.arrdem/lein-git-version "2.0.8"]]
 
   :git-version {:version-file      "target/classes/buildversion.edn"
-                :version-file-keys [:ref :version :branch]}
+                :version-file-keys [:ref :version :branch :message]}
 
   :profiles {:uberjar {:prep-tasks ["compile" "resource"]}
              :plugins [[lein-ring "0.11.0"]]

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,11 @@
   :plugins [[lein-resource "14.10.2"]
             [lein-autoreload "0.1.1"]
             [com.jakemccrary/lein-test-refresh "0.21.1"]
-            [lein-deploy-artifacts "0.1.0"]]
+            [lein-deploy-artifacts "0.1.0"]
+            [me.arrdem/lein-git-version "2.0.8"]]
+
+  :git-version {:version-file      "target/classes/buildversion.edn"
+                :version-file-keys [:ref :version :branch]}
 
   :profiles {:uberjar {:prep-tasks ["compile" "resource"]}
              :plugins [[lein-ring "0.11.0"]]

--- a/resources/ulkoiset-rajapinnat-oph.properties
+++ b/resources/ulkoiset-rajapinnat-oph.properties
@@ -22,7 +22,7 @@ valinta-tulos-service.internal.streaming-hakemukset = ${valinta-tulos-service.in
 
 tarjonta-service.base = ${host-virkailija}/tarjonta-service
 tarjonta-service.rest-v1 = ${tarjonta-service.base}/rest/v1
-tarjonta-service.haku-find-by-hakuvuosi = ${tarjonta-service.rest-v1}/haku/find?TILA=JULKAISTU&HAKUVUOSI=$1
+tarjonta-service.haku-find-by-hakuvuosi = ${tarjonta-service.rest-v1}/haku/findByAlkamisvuosi/$1
 tarjonta-service.hakukohde-search-by-haku-oid = ${tarjonta-service.rest-v1}/hakukohde/search?hakuOid=$1&tila=JULKAISTU
 tarjonta-service.haku-hakukohde-tulos= ${tarjonta-service.rest-v1}/haku/$1/hakukohdeTulos?hakukohdeTilas=JULKAISTU&count=-1
 tarjonta-service.koulutus-search-by-haku-oid = ${tarjonta-service.rest-v1}/koulutus/search?hakuOid=$1

--- a/src/ulkoiset_rajapinnat/core.clj
+++ b/src/ulkoiset_rajapinnat/core.clj
@@ -102,7 +102,14 @@
       :summary "Not found page"
       (access-log (not-found "Page not found")))))
 
+(defn- initialise-uncaught-exception-handler []
+  (Thread/setDefaultUncaughtExceptionHandler
+    (reify Thread$UncaughtExceptionHandler
+      (uncaughtException [_ thread ex]
+        (log/error ex "Uncaught exception on" (.getName thread))))))
+
 (defn start-server [args]
+  (initialise-uncaught-exception-handler)
   (init-config args)
   (let [port (-> @config :server :port)]
 

--- a/src/ulkoiset_rajapinnat/core.clj
+++ b/src/ulkoiset_rajapinnat/core.clj
@@ -34,15 +34,15 @@
       (GET "/healthcheck" []
         :summary "Health check API"
         (access-log (ok "OK")))
-      (GET "/haku-for-year/:vuosi" [vuosi ticket]
-        :summary "Haut vuodella"
+      (GET "/haku-for-year/:koulutuksen_alkamisvuosi" [koulutuksen_alkamisvuosi ticket]
+        :summary "Haut koulutuksen alkamisvuodella"
         :query-params [ticket :- String]
         :responses {200 {:schema [Haku]}}
-        (log/info (str "Got incoming request to /haku-for-year/" vuosi))
+        (log/info (str "Got incoming request to /haku-for-year/" koulutuksen_alkamisvuosi))
         (access-log-with-ticket-check-with-channel
           ticket
-          (partial audit audit-logger (str "Haut vuodella " vuosi))
-          (partial haku-resource vuosi)))
+          (partial audit audit-logger (str "Haut koulutuksen alkamisvuodella " koulutuksen_alkamisvuosi))
+          (partial haku-resource koulutuksen_alkamisvuosi)))
       (GET "/hakukohde-for-haku/:haku-oid" [haku-oid palauta-null-arvot ticket]
         :summary "Hakukohteet haku OID:lla"
         :query-params [ticket :- String]

--- a/src/ulkoiset_rajapinnat/core.clj
+++ b/src/ulkoiset_rajapinnat/core.clj
@@ -16,7 +16,8 @@
         [ulkoiset-rajapinnat.valintaperusteet :refer [Valintaperusteet valintaperusteet-resource]]
         [ulkoiset-rajapinnat.utils.config :refer [config init-config]]
         [org.httpkit.server :refer :all]
-        [clojure.tools.logging :as log])
+        [clojure.tools.logging :as log]
+        [clojure.tools.reader.edn :as edn])
   (:gen-class))
 
 (defn api-opintopolku-routes [audit-logger]
@@ -92,6 +93,11 @@
            ticket
           (partial audit audit-logger (str "Hakukohteet valintaperusteista"))
           (partial valintaperusteet-resource))))
+    (context (str (-> @config :server :base-url) "") []
+      (GET "/buildversion.txt" []
+        :summary "Build fingerprint"
+        (let [build-props (edn/read-string (slurp (clojure.java.io/resource "buildversion.edn")))]
+          (access-log (ok build-props)))))
     (ANY "/*" []
       :summary "Not found page"
       (access-log (not-found "Page not found")))))

--- a/src/ulkoiset_rajapinnat/core.clj
+++ b/src/ulkoiset_rajapinnat/core.clj
@@ -51,28 +51,28 @@
           ticket
           (partial audit audit-logger (str "Hakukohteet haku OID:lla" haku-oid))
           (partial hakukohde-resource haku-oid palauta-null-arvot)))
-      (GET "/vastaanotto-for-haku/:haku-oid" [haku-oid vuosi kausi ticket] ; hakuoid + kaudet
+      (GET "/vastaanotto-for-haku/:haku-oid" [haku-oid koulutuksen_alkamisvuosi koulutuksen_alkamiskausi ticket] ; hakuoid + kaudet
         :summary "Vastaanotot haku OID:lla"
         :query-params [ticket :- String
-                       vuosi :- String
-                       kausi :- String]
+                       koulutuksen_alkamisvuosi :- String
+                       koulutuksen_alkamiskausi :- String]
         :responses {200 {:schema [Vastaanotto]}}
         (log/info (str "Got incoming request to /vastaanotto-for-haku/" haku-oid))
         (access-log-with-ticket-check-with-channel
            ticket
           (partial audit audit-logger (str "Vastaanotot haku OID:lla" haku-oid))
-          (partial vastaanotto-resource haku-oid vuosi kausi)))
-      (GET "/hakemus-for-haku/:haku-oid" [haku-oid vuosi kausi palauta-null-arvot ticket] ; hakuoid + kaudet
+          (partial vastaanotto-resource haku-oid koulutuksen_alkamisvuosi koulutuksen_alkamiskausi)))
+      (GET "/hakemus-for-haku/:haku-oid" [haku-oid koulutuksen_alkamisvuosi koulutuksen_alkamiskausi palauta-null-arvot ticket] ; hakuoid + kaudet
         :summary "Hakemukset haku OID:lla"
         :query-params [ticket :- String
-                       vuosi :- String
-                       kausi :- String]
+                       koulutuksen_alkamisvuosi :- String
+                       koulutuksen_alkamiskausi :- String]
         :responses {200 {:schema [Hakemus]}}
-        (log/info (str "Got incoming request to /hakemus-for-haku/" haku-oid "?vuosi=" vuosi "&kausi=" kausi))
+        (log/info (str "Got incoming request to /hakemus-for-haku/" haku-oid "?koulutuksen_alkamisvuosi=" koulutuksen_alkamisvuosi "&koulutuksen_alkamiskausi=" koulutuksen_alkamiskausi))
         (access-log-with-ticket-check-with-channel
            ticket
           (partial audit audit-logger (str "Vastaanotot haku OID:lla" haku-oid))
-          (partial hakemus-resource haku-oid vuosi kausi palauta-null-arvot)))
+          (partial hakemus-resource haku-oid koulutuksen_alkamisvuosi koulutuksen_alkamiskausi palauta-null-arvot)))
       (GET "/valintaperusteet/hakukohde/:hakukohde-oid" [hakukohde-oid ticket]
         :summary "Hakukohde valintaperusteista"
         :query-params [ticket :- String]

--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -261,7 +261,7 @@
                (log/info "Returned successfully" @counter "'hakemusta' from Haku-App and Ataru! Took" (- (System/currentTimeMillis) start-time) "ms!")
                (catch Throwable e
                  (do
-                   (log/error "Failed to write 'hakemukset'!" e)
+                   (log/error e "Failed to write 'hakemukset'!")
                    (write-object-to-channel is-first-written
                                             {:error (.getMessage e)}
                                             channel)
@@ -277,7 +277,7 @@
                               is-illegal-argument (or (instance? IllegalArgumentException e)
                                                       (instance? IllegalArgumentException (.getCause e)))
                               status-code (if is-illegal-argument 400 500)]
-                          (log/error "Exception in fetch-hakemukset-for-haku" e)
+                          (log/error e "Exception in fetch-hakemukset-for-haku")
                           (status channel status-code)
                           (body channel (to-json {:error error-message}))
                           (close channel)

--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -178,14 +178,19 @@
   (fn [batch] [(map #(get % "personOid") batch)
                batch
                (fn [henkilo-by-oid oppijat-by-oid hakemus is-toisen-asteen-haku? organisaatiot]
-                 (convert-hakemus
-                   pohjakoulutus-koodit
-                   palauta-null-arvot?
-                   (get henkilo-by-oid (get hakemus "personOid"))
-                   (get oppijat-by-oid (get hakemus "personOid"))
-                   hakemus
-                   is-toisen-asteen-haku?
-                   organisaatiot))]))
+                 (try
+                   (convert-hakemus
+                     pohjakoulutus-koodit
+                     palauta-null-arvot?
+                     (get henkilo-by-oid (get hakemus "personOid"))
+                     (get oppijat-by-oid (get hakemus "personOid"))
+                     hakemus
+                     is-toisen-asteen-haku?
+                     organisaatiot)
+                   (catch Exception e
+                     (do
+                       (log/error e "Problem when converting hakemus " hakemus)
+                       (throw e)))))]))
 
 (defn ataru-adapter [pohjakoulutus-koodit palauta-null-arvot?]
   (fn [batch] [(document-batch-to-henkilo-oid-list batch)

--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -261,7 +261,7 @@
                (log/info "Returned successfully" @counter "'hakemusta' from Haku-App and Ataru! Took" (- (System/currentTimeMillis) start-time) "ms!")
                (catch Throwable e
                  (do
-                   (log/error e "Failed to write 'hakemukset'!")
+                   (log/error "Failed to write 'hakemukset'!" e)
                    (write-object-to-channel is-first-written
                                             {:error (.getMessage e)}
                                             channel)
@@ -277,7 +277,7 @@
                               is-illegal-argument (or (instance? IllegalArgumentException e)
                                                       (instance? IllegalArgumentException (.getCause e)))
                               status-code (if is-illegal-argument 400 500)]
-                          (log/error e "Exception in fetch-hakemukset-for-haku")
+                          (log/error "Exception in fetch-hakemukset-for-haku" e)
                           (status channel status-code)
                           (body channel (to-json {:error error-message}))
                           (close channel)

--- a/src/ulkoiset_rajapinnat/utils/async_safe.clj
+++ b/src/ulkoiset_rajapinnat/utils/async_safe.clj
@@ -1,5 +1,5 @@
 (ns ulkoiset-rajapinnat.utils.async_safe
-  (:require [clojure.core.async :as async :refer [to-chan map]]))
+  (:require [clojure.core.async :as async]))
 
 ; ordinary async/map gets stuck when sources are empty! Use this function instead.
 (defn async-map-safe [f sources default-value]

--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -92,8 +92,8 @@
   (post-as-channel url nil {:form-params form} mapper))
 
 (defn post-json-options
-  ([] {:as :stream :timeout 200000 :headers {"Content-Type" mime-application-json}})
-  ([jsession-id] {:as :stream :timeout 200000 :headers {"Content-Type" mime-application-json "Cookie" (str "JSESSIONID=" jsession-id)}}))
+  ([] {:as :stream :timeout 400000 :headers {"Content-Type" mime-application-json}})
+  ([jsession-id] {:as :stream :timeout 400000 :headers {"Content-Type" mime-application-json "Cookie" (str "JSESSIONID=" jsession-id)}}))
 
 (defn post-json-as-channel
   ([url data mapper]

--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -29,7 +29,7 @@
     (try
       (parse-string (response :body))
       (catch Exception e
-        (log/error e "Failed to read JSON!" (get-in response [:opts :url]))
+        (log/error "Failed to read JSON!" (get-in response [:opts :url]) e)
         (throw e)))
     (handle-unexpected-response response)))
 
@@ -38,7 +38,7 @@
     (try
       (doall (parse-stream (new java.io.InputStreamReader (response :body))))
       (catch Exception e
-        (log/error e "Failed to read JSON! Url = " (get-in response [:opts :url]))
+        (log/error "Failed to read JSON! Url = " (get-in response [:opts :url]) e)
         (throw e)))
     (handle-unexpected-response response)))
 
@@ -118,7 +118,7 @@
 (defn exception-response [channel]
   (fn [exception]
     (do
-      (log/error exception "Internal server error!")
+      (log/error "Internal server error!" exception)
       (-> channel
           (status 500)
           (body (to-json {:error (.getMessage exception)}))

--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -29,7 +29,7 @@
     (try
       (parse-string (response :body))
       (catch Exception e
-        (log/error "Failed to read JSON!" (get-in response [:opts :url]) e)
+        (log/error e "Failed to read JSON!" (get-in response [:opts :url]))
         (throw e)))
     (handle-unexpected-response response)))
 
@@ -38,7 +38,7 @@
     (try
       (doall (parse-stream (new java.io.InputStreamReader (response :body))))
       (catch Exception e
-        (log/error "Failed to read JSON! Url = " (get-in response [:opts :url]) e)
+        (log/error e "Failed to read JSON! Url = " (get-in response [:opts :url]))
         (throw e)))
     (handle-unexpected-response response)))
 
@@ -118,7 +118,7 @@
 (defn exception-response [channel]
   (fn [exception]
     (do
-      (log/error "Internal server error!" exception)
+      (log/error exception "Internal server error!")
       (-> channel
           (status 500)
           (body (to-json {:error (.getMessage exception)}))

--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -61,10 +61,12 @@
   (let [p (promise-chan)
         options-with-ids (update-in options [:headers] assoc
                                     "Caller-Id" "fi.opintopolku.ulkoiset-rajapinnat"
-                                    "clientSubSystemCode" "fi.opintopolku.ulkoiset-rajapinnat")]
+                                    "clientSubSystemCode" "fi.opintopolku.ulkoiset-rajapinnat")
+        start-time (System/currentTimeMillis)]
     (method url options-with-ids
       #(go
         (do (>! p (transform-response mapper %))
+          (log/info "Response came in" (- (System/currentTimeMillis) start-time) "ms from" url)
           (close! p))))
     p))
 

--- a/src/ulkoiset_rajapinnat/utils/tarjonta.clj
+++ b/src/ulkoiset_rajapinnat/utils/tarjonta.clj
@@ -84,6 +84,8 @@
        (str/starts-with? (get haku "koulutuksenAlkamiskausiUri") (to-kausi-uri-prefix kausi))))
 
 (defn- hakukohde-oidit-koulutuksen-alkamiskauden-ja-vuoden-mukaan-yhteishaulle [yhteishaku vuosi kausi]
+  (log/info "Haku" (get yhteishaku "oid") "(" (get-in yhteishaku ["nimi" "kieli_fi"])
+            ") on yhteishaku, joten sen alkamiskausikohtaisten hakukohteiden listaus on helppoa.")
   (if (has-koulutuksen-alkamiskausi yhteishaku vuosi kausi)
     (get yhteishaku "hakukohdeOids")
     []))

--- a/src/ulkoiset_rajapinnat/utils/tarjonta.clj
+++ b/src/ulkoiset_rajapinnat/utils/tarjonta.clj
@@ -52,6 +52,13 @@
       false)
     (throw (RuntimeException. "Can't check nil haku if it's toisen asteen haku!"))))
 
+(defn is-yhteishaku [haku]
+  (if haku
+    (if-let [hakutapa (haku "hakutapaUri")]
+      (str/starts-with? hakutapa "hakutapa_01#")
+      false)
+    (throw (RuntimeException. "Can't check nil haku if it's yhteishaku!"))))
+
 (defn is-jatkuva-haku [haku]
   (if-let [some-haku haku]
     (if-let [hakutapa (haku "hakutapaUri")]
@@ -72,18 +79,32 @@
       kausi-uri-prefix-syksy
       (throw (IllegalArgumentException. (str "Unknown kausi param: " kausi))))))
 
+(defn- has-koulutuksen-alkamiskausi [haku vuosi kausi]
+  (and (= (str (get haku "koulutuksenAlkamisVuosi")) vuosi)
+       (str/starts-with? (get haku "koulutuksenAlkamiskausiUri") (to-kausi-uri-prefix kausi))))
+
+(defn- hakukohde-oidit-koulutuksen-alkamiskauden-ja-vuoden-mukaan-yhteishaulle [yhteishaku vuosi kausi]
+  (if (has-koulutuksen-alkamiskausi yhteishaku vuosi kausi)
+    (get yhteishaku "hakukohdeOids")
+    []))
+
+(defn- has-koulutuksen-alkamiskausi? [alkamisvuosi alkamiskausi hakukohde]
+  (let [kausi-uri-prefix (to-kausi-uri-prefix alkamiskausi)]
+    (if-let [alkamiskausiUri (get hakukohde "koulutuksenAlkamiskausiUri")]
+      (if-let [alkamisVuosi (get hakukohde "koulutuksenAlkamisVuosi")]
+        (and (= (str alkamisVuosi) alkamisvuosi) (str/starts-with? alkamiskausiUri kausi-uri-prefix))
+        false)
+      false)))
+
 (defn hakukohde-oidit-koulutuksen-alkamiskauden-ja-vuoden-mukaan
   ([haku-oid vuosi kausi] (hakukohde-oidit-koulutuksen-alkamiskauden-ja-vuoden-mukaan haku-oid vuosi kausi nil))
   ([haku-oid vuosi kausi valmis-haku]
    (when (not (is-valid-year vuosi))
      (throw (IllegalArgumentException. (str "Invalid vuosi: " vuosi))))
-   (go-try (let [kausi-uri-prefix (to-kausi-uri-prefix kausi)
-                 haku (if (nil? valmis-haku) (<? (haku-for-haku-oid-channel haku-oid)) valmis-haku)
-                 hakukohde-oids (get haku "hakukohdeOids")
-                 hakukohteiden-koulutusten-alkamiskaudet (<? (fetch-tilastoskeskus-hakukohde-channel hakukohde-oids))
-                 koulutuksen-alkamiskausi? (fn [x] (if-let [alkamiskausiUri (get x "koulutuksenAlkamiskausiUri")]
-                                                     (if-let [alkamisVuosi (get x "koulutuksenAlkamisVuosi")]
-                                                       (and (= (str alkamisVuosi) vuosi) (str/starts-with? alkamiskausiUri kausi-uri-prefix))
-                                                       false)
-                                                     false))]
-             (map #(get % "hakukohdeOid") (filter koulutuksen-alkamiskausi? hakukohteiden-koulutusten-alkamiskaudet))))))
+   (go-try (let [haku (if (nil? valmis-haku) (<? (haku-for-haku-oid-channel haku-oid)) valmis-haku)
+                 hakukohde-oids (get haku "hakukohdeOids")]
+             (if (is-yhteishaku haku)
+               (hakukohde-oidit-koulutuksen-alkamiskauden-ja-vuoden-mukaan-yhteishaulle haku vuosi kausi)
+               (let [hakukohteiden-koulutusten-alkamiskaudet (<? (fetch-tilastoskeskus-hakukohde-channel hakukohde-oids))
+                     koulutuksen-alkamiskausi? (partial has-koulutuksen-alkamiskausi? vuosi kausi)]
+                 (map #(get % "hakukohdeOid") (filter koulutuksen-alkamiskausi? hakukohteiden-koulutusten-alkamiskaudet))))))))

--- a/src/ulkoiset_rajapinnat/valintaperusteet.clj
+++ b/src/ulkoiset_rajapinnat/valintaperusteet.clj
@@ -137,7 +137,7 @@
                   (body-and-close json))))
           (catch Exception e
             (do
-              (log/error e (format "Virhe haettaessa valintaperusteita %d hakukohteelle!" (count requested-oids)))
+              (log/error (format "Virhe haettaessa valintaperusteita %d hakukohteelle!" (count requested-oids)), e)
               (log-to-access-log 500 (.getMessage e))
               ((exception-response channel) e)))))
    (schedule-task (* 1000 60 60) (close channel))))

--- a/src/ulkoiset_rajapinnat/valintaperusteet.clj
+++ b/src/ulkoiset_rajapinnat/valintaperusteet.clj
@@ -137,7 +137,7 @@
                   (body-and-close json))))
           (catch Exception e
             (do
-              (log/error (format "Virhe haettaessa valintaperusteita %d hakukohteelle!" (count requested-oids)), e)
+              (log/error e (format "Virhe haettaessa valintaperusteita %d hakukohteelle!" (count requested-oids)))
               (log-to-access-log 500 (.getMessage e))
               ((exception-response channel) e)))))
    (schedule-task (* 1000 60 60) (close channel))))

--- a/src/ulkoiset_rajapinnat/vastaanotto.clj
+++ b/src/ulkoiset_rajapinnat/vastaanotto.clj
@@ -225,7 +225,7 @@
           (log-to-access-log 404 message)))
       (catch Exception e
         (do
-          (log/error (format "Virhe haettaessa vastaanottoja haulle %s!" haku-oid), e)
+          (log/error e (format "Virhe haettaessa vastaanottoja haulle %s!" haku-oid))
           (log-to-access-log 500 (.getMessage e))
           ((exception-response channel) e))))))
 

--- a/src/ulkoiset_rajapinnat/vastaanotto.clj
+++ b/src/ulkoiset_rajapinnat/vastaanotto.clj
@@ -178,8 +178,8 @@
           mapper (comp find-kielikokeet parse-json-body-stream)
           post (fn [x] (post-json-as-channel url x mapper jsession-id))
           partitions (partition oppijat-batch-size oppijat-batch-size nil kaikki-oppijanumerot)
-          valintaperusteet (<? (async-map-safe vector (map #(post %) partitions) []))]
-      (apply merge valintaperusteet))))
+          kielikokeet (<? (async-map-safe vector (map #(post %) partitions) []))]
+      (apply merge kielikokeet))))
 
 (defn- filter-vastaanotot [haun-hakukohdeoidit haun-vastaanotot haku-oid vuosi kausi]
   (if (not-empty haun-hakukohdeoidit)

--- a/src/ulkoiset_rajapinnat/vastaanotto.clj
+++ b/src/ulkoiset_rajapinnat/vastaanotto.clj
@@ -225,7 +225,7 @@
           (log-to-access-log 404 message)))
       (catch Exception e
         (do
-          (log/error e (format "Virhe haettaessa vastaanottoja haulle %s!" haku-oid))
+          (log/error (format "Virhe haettaessa vastaanottoja haulle %s!" haku-oid), e)
           (log-to-access-log 500 (.getMessage e))
           ((exception-response channel) e))))))
 

--- a/src/ulkoiset_rajapinnat/vastaanotto.clj
+++ b/src/ulkoiset_rajapinnat/vastaanotto.clj
@@ -12,7 +12,8 @@
             [ulkoiset-rajapinnat.utils.snippets :refer [find-first-matching get-value-if-not-nil]]
             [ulkoiset-rajapinnat.utils.async_safe :refer :all]
             [org.httpkit.server :refer :all]
-            [org.httpkit.timer :refer :all]))
+            [org.httpkit.timer :refer :all])
+  (:import (java.time Duration)))
 
 (s/defschema Vastaanotto
   {:henkilo_oid                  s/Str
@@ -35,6 +36,7 @@
 
 (def oppijat-batch-size 5000)
 (def valintapisteet-batch-size 30000)
+(def valinta-tulos-service-timeout-millis (.toMillis (. Duration ofMinutes 30)))
 
 (defn vastaanotto-builder [kokeet valintapisteet kielikokeet]
   (defn- hyvaksytty-ensikertalaisen-hakijaryhmasta [hakijaryhmat]
@@ -147,7 +149,7 @@
 
 (defn vastaanotot-whole-haku-channel [haku-oid]
   (log/info (format "Haku %s haetaan vastaanotot..." haku-oid))
-  (get-as-channel (resolve-url :valinta-tulos-service.internal.streaming-hakemukset haku-oid) {:as :stream :timeout 600000} parse-json-body-stream))
+  (get-as-channel (resolve-url :valinta-tulos-service.internal.streaming-hakemukset haku-oid) {:as :stream :timeout valinta-tulos-service-timeout-millis} parse-json-body-stream))
 
 (defn fetch-kokeet-channel [haku-oid hakukohde-oidit]
   (log/info (format "Haku %s haetaan valintakokeet %d hakukohteelle..." haku-oid (count hakukohde-oidit)))

--- a/src/ulkoiset_rajapinnat/vastaanotto.clj
+++ b/src/ulkoiset_rajapinnat/vastaanotto.clj
@@ -90,13 +90,17 @@
          "osallistui_kielikokeeseen"                  kielikokeeseen-osallistuminen})))
 
   (fn [vastaanotto]
-    (let [hakemus-oid (vastaanotto "hakemusOid")
-          hakija-oid (vastaanotto "hakijaOid")
-          hakemuksen-pisteet (valintapisteet hakemus-oid)
-          hakijan-kielikokeet (kielikokeet hakija-oid)
-          build-hakutoive (hakutoive-builder kokeet hakemuksen-pisteet hakijan-kielikokeet)]
-      {"henkilo_oid" hakija-oid
-       "hakutoiveet" (map build-hakutoive (vastaanotto "hakutoiveet"))})))
+    (try
+      (let [hakemus-oid (vastaanotto "hakemusOid")
+                hakija-oid (vastaanotto "hakijaOid")
+                hakemuksen-pisteet (valintapisteet hakemus-oid)
+                hakijan-kielikokeet (kielikokeet hakija-oid)
+                build-hakutoive (hakutoive-builder kokeet hakemuksen-pisteet hakijan-kielikokeet)]
+            {"henkilo_oid" hakija-oid
+             "hakutoiveet" (map build-hakutoive (vastaanotto "hakutoiveet"))})
+      (catch Exception e
+        (log/error (format "Virhe muodostettaessa vastaanottotietoa vastaanotosta %s" vastaanotto) e)
+        (throw e)))))
 
 (defn find-valintakokeet [valintaperusteet]
   (defn- transform-dto [dto]

--- a/src/ulkoiset_rajapinnat/vastaanotto.clj
+++ b/src/ulkoiset_rajapinnat/vastaanotto.clj
@@ -99,8 +99,9 @@
             {"henkilo_oid" hakija-oid
              "hakutoiveet" (map build-hakutoive (vastaanotto "hakutoiveet"))})
       (catch Exception e
-        (log/error (format "Virhe muodostettaessa vastaanottotietoa vastaanotosta %s" vastaanotto) e)
-        (throw e)))))
+        (do
+          (log/error (format "Virhe muodostettaessa vastaanottotietoa vastaanotosta %s" vastaanotto) e)
+          (throw e))))))
 
 (defn find-valintakokeet [valintaperusteet]
   (defn- transform-dto [dto]

--- a/test/resources/hakukohde/result.json
+++ b/test/resources/hakukohde/result.json
@@ -2,6 +2,7 @@
   "hakukohteen_nimi" : {
     "fi" : "Kuvataiteilija (ylempi AMK), Kuvataide, Imatra, lisähaku"
   },
+  "koulutuksen_alkamisvuosi": 2017,
   "organisaatiot" : [ {
     "organisaation_oid" : "1.2.246.562.10.82958623314",
     "organisaation_kuntakoodi" : "153",
@@ -10,6 +11,7 @@
       "en" : "Ankkalinna University of Applied Sciences"
     }
   } ],
+  "koulutuksen_alkamiskausi": "k",
   "koulutuksen_opetuskieli" : [ "FI" ],
   "hakukohteen_oid" : "1.2.246.562.20.573444383210",
   "hakijalle_ilmoitetut_aloituspaikat" : 3,
@@ -20,6 +22,7 @@
   "hakukohteen_nimi" : {
     "fi" : "Agrologi (AMK), monimuotototeutus, lisähaku"
   },
+  "koulutuksen_alkamisvuosi": 2017,
   "organisaatiot" : [ {
     "organisaation_oid" : "1.2.246.562.10.72590401013",
     "organisaation_kuntakoodi" : "145",
@@ -27,6 +30,7 @@
       "fi" : "Ankkalinnan yliopisto"
     }
   } ],
+  "koulutuksen_alkamiskausi": "k",
   "koulutuksen_opetuskieli" : [ "FI" ],
   "hakukohteen_oid" : "1.2.246.562.20.22971087097",
   "ensikertalaisten_aloituspaikat" : 0,

--- a/test/ulkoiset_rajapinnat/core_test.clj
+++ b/test/ulkoiset_rajapinnat/core_test.clj
@@ -13,6 +13,15 @@
           status (-> response :status)]
       (is (= status 200)))))
 
+(deftest buildversion-text
+  (testing "Health check API"
+    (let [response (client/get (api-call "/buildversion.txt"))
+          status (-> response :status)
+          body (-> response :body)]
+      (is (= status 200))
+      (is (re-find #"ref" body))
+      (is (re-find #"branch" body)))))
+
 (deftest unexpected-response-test
   (testing "Not 200 status code"
     (try

--- a/test/ulkoiset_rajapinnat/hakemus_test.clj
+++ b/test/ulkoiset_rajapinnat/hakemus_test.clj
@@ -44,7 +44,7 @@
     (testing "Fetch hakemukset for haku with no hakemuksia!"
       (with-redefs [fetch-hakemukset-from-ataru (mock-mapped [])
                     fetch-hakemukset-from-haku-app-as-streaming-channel (mock-mapped [])]
-        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?vuosi=2017&kausi=kausi_s%231"))
+        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s%231"))
               status (-> response :status)
               body (response :body)]
           (is (= status 200))
@@ -53,7 +53,7 @@
     (testing "Fetch hakemukset for haku with 'ataru' hakemuksia!"
       (with-redefs [fetch-hakemukset-from-ataru (mock-mapped [{"oid" "1.2.3.4.5.6"}])
                     fetch-hakemukset-from-haku-app-as-streaming-channel (mock-mapped [])]
-        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?vuosi=2017&kausi=kausi_s%231")
+        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s%231")
                                    {:as :json})
               status (-> response :status)
               body (response :body)]
@@ -63,7 +63,7 @@
     (testing "Fetch hakemukset for haku with 'haku-app' hakemuksia!"
       (with-redefs [fetch-hakemukset-from-ataru (mock-mapped [])
                     fetch-hakemukset-from-haku-app-as-streaming-channel (mock-mapped [{"oid" "1.2.3.4"}])]
-        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?vuosi=2017&kausi=kausi_s%231")
+        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s%231")
                                    {:as :json})
               status (-> response :status)
               body (response :body)]
@@ -123,7 +123,7 @@
                   http/get (fn [url options transform] (mock-http url options transform))
                   http/post (fn [url options transform] (mock-http url options transform))
                   fetch-jsessionid-channel (mock-channel-fn "FAKEJSESSIONID")]
-      (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?vuosi=2017&kausi=kausi_s"))
+      (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s"))
             status (-> response :status)
             body (-> (parse-json-body response))]
         (is (= status 200))
@@ -153,7 +153,7 @@
                   fetch-hakemukset-from-haku-app-as-streaming-channel (mock-mapped [])
                   http/get (fn [url options transform] (mock-ataru-http url options transform))
                   http/post (fn [url options transform] (mock-ataru-http url options transform))]
-      (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?vuosi=2017&kausi=kausi_s"))
+      (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s"))
             status (-> response :status)
             body (-> (parse-json-body response))]
         (is (= status 200))
@@ -188,7 +188,7 @@
       (let [access-log-mock (pico/mock mock-write-access-log)]
         (with-redefs [write-access-log access-log-mock]
           (try
-            (let [response (client/get (api-call "/api/hakemus-for-haku/ABC?vuosi=2017&kausi=kausi_s"))]
+            (let [response (client/get (api-call "/api/hakemus-for-haku/ABC?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s"))]
               (is (= false true) "should not reach this line"))
             (catch Exception e
               (assert-access-log-write access-log-mock 404 "Haku ABC not found")
@@ -199,7 +199,7 @@
       (let [access-log-mock (pico/mock mock-write-access-log)]
         (with-redefs [write-access-log access-log-mock]
           (try
-            (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?vuosi=2017&kausi=ABC"))]
+            (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=ABC"))]
               (is (= false true) "should not reach this line"))
             (catch Exception e
               (assert-access-log-write access-log-mock 400 "Unknown kausi param: ABC")
@@ -210,7 +210,7 @@
       (let [access-log-mock (pico/mock mock-write-access-log)]
         (with-redefs [write-access-log access-log-mock]
           (try
-            (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?vuosi=-2017&kausi=s"))]
+            (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=-2017&koulutuksen_alkamiskausi=s"))]
               (is (= false true) "should not reach this line"))
             (catch Exception e
               (assert-access-log-write access-log-mock 400 "Invalid vuosi: -2017")
@@ -221,7 +221,7 @@
       (let [access-log-mock (pico/mock mock-write-access-log)]
         (with-redefs [fetch-hakemukset-from-ataru (mock-mapped [])
                       write-access-log access-log-mock]
-          (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?vuosi=2015&kausi=s"))
+          (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=2015&koulutuksen_alkamiskausi=s"))
                 status (-> response :status)
                 body (-> response :body)]
             (assert-access-log-write access-log-mock 200 nil)

--- a/test/ulkoiset_rajapinnat/hakemus_test.clj
+++ b/test/ulkoiset_rajapinnat/hakemus_test.clj
@@ -73,7 +73,7 @@
     (testing "When haku-app gives 2aste hakemus, the result will have the 2aste pohjakoulutus field!"
       (with-redefs [fetch-hakemukset-from-ataru (mock-mapped [])
                     fetch-hakemukset-from-haku-app-as-streaming-channel (fn [x y z mapper] (go (mapper (parse-string hakemus-2aste-json))))]
-        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?vuosi=2017&kausi=kausi_s%231")
+        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s%231")
                                    {:as :json})
               status (-> response :status)
               hakemus (first (response :body))]
@@ -86,7 +86,7 @@
       (with-redefs [fetch-hakemukset-from-ataru (mock-mapped [])
                     fetch-hakemukset-from-haku-app-as-streaming-channel (fn [x y z mapper] (go (mapper (parse-string hakemus-kk-json))))
                     koodisto-as-channel (mock-channel-fn {"koodi1" "pohjakoulutus_amt", "koodi2" "dummy_value", "koodi3" "pohjakoulutus_kk"})]
-        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?vuosi=2017&kausi=kausi_s%231")
+        (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.94986312133?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s%231")
                                    {:as :json})
               status (-> response :status)
               hakemus (first (response :body))]

--- a/test/ulkoiset_rajapinnat/hakemus_test.clj
+++ b/test/ulkoiset_rajapinnat/hakemus_test.clj
@@ -123,7 +123,7 @@
                   http/get (fn [url options transform] (mock-http url options transform))
                   http/post (fn [url options transform] (mock-http url options transform))
                   fetch-jsessionid-channel (mock-channel-fn "FAKEJSESSIONID")]
-      (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=kausi_s"))
+      (let [response (client/get (api-call "/api/hakemus-for-haku/1.2.246.562.29.999999?koulutuksen_alkamisvuosi=2018&koulutuksen_alkamiskausi=kausi_s"))
             status (-> response :status)
             body (-> (parse-json-body response))]
         (is (= status 200))

--- a/test/ulkoiset_rajapinnat/haku_test.clj
+++ b/test/ulkoiset_rajapinnat/haku_test.clj
@@ -46,7 +46,7 @@
     "http://fake.virkailija.opintopolku.fi/koodisto-service/rest/codeelement/codes/haunkohdejoukontarkenne/1" (response 200 koodisto-haunkohdejoukontarkenne-json)
     "http://fake.virkailija.opintopolku.fi/koodisto-service/rest/codeelement/codes/kausi/1" (response 200 koodisto-kausi-json)
     "http://fake.virkailija.opintopolku.fi/koodisto-service/rest/codeelement/codes/kieli/1" (response 200 koodisto-kieli-json)
-    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/find?TILA=JULKAISTU&HAKUVUOSI=2017" (response 200 tarjonta-haut-json)
+    "http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/findByAlkamisvuosi/2017" (response 200 tarjonta-haut-json)
     (response 404 "[]")))
 
 (deftest haku-test

--- a/test/ulkoiset_rajapinnat/vastaanotto_test.clj
+++ b/test/ulkoiset_rajapinnat/vastaanotto_test.clj
@@ -58,7 +58,7 @@
                     fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))
                     write-access-log access-log-mock]
         (try
-          (let [response (client/get (api-call "/api/vastaanotto-for-haku/INVALID_HAKU?vuosi=2017&kausi=s"))]
+          (let [response (client/get (api-call "/api/vastaanotto-for-haku/INVALID_HAKU?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))]
             (is (= false true)))
           (catch Exception e
             (assert-access-log-write access-log-mock 404 "Haku INVALID_HAKU not found")
@@ -74,7 +74,7 @@
                     fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))
                     write-access-log access-log-mock]
         (try
-          (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?vuosi=2017&kausi=s"))]
+          (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))]
             (is (= false true)))
           (catch Exception e
             (assert-access-log-write access-log-mock 500 "Unexpected response status 404 from url http://fake.virkailija.opintopolku.fi/tarjonta-service/rest/v1/haku/1.2.246.562.29.25191045126")
@@ -89,7 +89,7 @@
                     http/post (fn [url options transform] (mock-http url options transform))
                     fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))
                     write-access-log access-log-mock]
-        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?vuosi=2017&kausi=s"))
+        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))
               status (-> response :status)
               body (-> (parse-json-body response))]
           (is (= status 200))
@@ -108,7 +108,7 @@
                     http/post (fn [url options transform] (mock-http url options transform :empty-avaimet))
                     fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))
                     write-access-log access-log-mock]
-        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?vuosi=2017&kausi=s"))
+        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))
               status (-> response :status)
               body (-> (parse-json-body response))]
           (is (= status 200))
@@ -160,7 +160,7 @@
                   http/post (fn [url options transform] (mock-http-with-ise url options transform))
                   fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))]
       (try
-        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?vuosi=2017&kausi=s"))]
+        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))]
           (is (= false true)))
         (catch Exception e
           (do
@@ -170,7 +170,7 @@
                   http/get (fn [url options transform] (mock-http-no-vastaanotot url options transform))
                   http/post (fn [url options transform] (mock-http-no-vastaanotot url options transform))
                   fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))]
-      (try (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?vuosi=2017&kausi=s"))
+      (try (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))
                  status (-> response :status)
                  body (-> (parse-json-body response))]
              (is (= status 200))

--- a/test/ulkoiset_rajapinnat/vastaanotto_test.clj
+++ b/test/ulkoiset_rajapinnat/vastaanotto_test.clj
@@ -89,7 +89,7 @@
                     http/post (fn [url options transform] (mock-http url options transform))
                     fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))
                     write-access-log access-log-mock]
-        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))
+        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2018&koulutuksen_alkamiskausi=k"))
               status (-> response :status)
               body (-> (parse-json-body response))]
           (is (= status 200))
@@ -108,7 +108,7 @@
                     http/post (fn [url options transform] (mock-http url options transform :empty-avaimet))
                     fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))
                     write-access-log access-log-mock]
-        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))
+        (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2018&koulutuksen_alkamiskausi=k"))
               status (-> response :status)
               body (-> (parse-json-body response))]
           (is (= status 200))
@@ -170,7 +170,7 @@
                   http/get (fn [url options transform] (mock-http-no-vastaanotot url options transform))
                   http/post (fn [url options transform] (mock-http-no-vastaanotot url options transform))
                   fetch-jsessionid-channel (fn [a] (mock-channel "FAKEJSESSIONID"))]
-      (try (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2017&koulutuksen_alkamiskausi=s"))
+      (try (let [response (client/get (api-call "/api/vastaanotto-for-haku/1.2.246.562.29.25191045126?koulutuksen_alkamisvuosi=2018&koulutuksen_alkamiskausi=k"))
                  status (-> response :status)
                  body (-> (parse-json-body response))]
              (is (= status 200))


### PR DESCRIPTION
vastaanotto-for-haku -APIa on tehty hieman selkeämmäksi ja tehokkaammaksi, ynnä muutamia muita pieniä parannuksia.

Valitettavasti tämä ei yksinään tunnu riittävän saamaan ison haun dataa ulos ainakaan QA-ympäristössä.

- vastaanotto-for-haku -APIn prosessointia rinnakkaisemmaksi: valintakokeet, valintapisteet ja kielikokeet haetaan rinnakkain
- vuosi- ja kausi-parametrien selkeyttäminen: puhutaan aina koulutuksen alkamiskaudesta, ei hakukaudesta
- oikeiden hakujen hakeminen haku-for-year -APIlla: koulutuksen alkamiskauden mukaan, ei hakukauden
- koulutusten alkamiskaudet näkyviin hakukohteille
- isompia timeout-arvoja, koska jotkut pyynnöt voivat kestää pitkään

- palvelun tekemien HTTP-pyyntöjen kestojen logitus
- parempi poikkeusten logitus, myös async-threadeista
- pienimuotoinen buildversion.txt -toteutus
- stdlibin map:in piilottamisen kääntäjävaroitus pois
- leiningen- ja Clojure-päivitys