### PR TITLE
BUG-1865 ytunnus ja oppilaitoskoodi parent-organisaatiolta...

### DIFF
--- a/test/resources/hakukohde/organisaatio.json
+++ b/test/resources/hakukohde/organisaatio.json
@@ -231,7 +231,9 @@
     "maaUri": "maatjavaltiot1_fin",
     "toimipistekoodi": "0247213",
     "version": 38,
-    "status": "AKTIIVINEN"
+    "status": "AKTIIVINEN",
+    "ytunnus": "100200",
+    "oppilaitosKoodi": "00000"
   },
   {
     "yhteishaunKoulukoodi": "1231",
@@ -476,6 +478,8 @@
     "maaUri": "maatjavaltiot1_fin",
     "toimipistekoodi": "0260903",
     "version": 49,
-    "status": "AKTIIVINEN"
+    "status": "AKTIIVINEN",
+    "ytunnus": "100200",
+    "oppilaitosKoodi": "00000"
   }
 ]

--- a/test/resources/hakukohde/result.json
+++ b/test/resources/hakukohde/result.json
@@ -5,6 +5,8 @@
   "koulutuksen_alkamisvuosi": 2017,
   "organisaatiot" : [ {
     "organisaation_oid" : "1.2.246.562.10.82958623314",
+    "koulutustoimijan_ytunnus": "100200",
+    "oppilaitos_koodi": "00000",
     "organisaation_kuntakoodi" : "153",
     "organisaation_nimi" : {
       "fi" : "Ankkalinnan ammattikorkeakoulu",
@@ -26,6 +28,8 @@
   "organisaatiot" : [ {
     "organisaation_oid" : "1.2.246.562.10.72590401013",
     "organisaation_kuntakoodi" : "145",
+    "koulutustoimijan_ytunnus": "100200",
+    "oppilaitos_koodi": "00000",
     "organisaation_nimi" : {
       "fi" : "Ankkalinnan yliopisto"
     }


### PR DESCRIPTION
...mikäli näitä ei organisaatiolla itsellään ole määritelty.

`<? fetch` ei voi tehdä nestatusti, ks. https://stackoverflow.com/questions/45971689/why-assert-failed-used-not-in-go-block