### PR TITLE
Increase default POST timeout.

### DIFF
--- a/src/ulkoiset_rajapinnat/utils/rest.clj
+++ b/src/ulkoiset_rajapinnat/utils/rest.clj
@@ -94,8 +94,8 @@
   (post-as-channel url nil {:form-params form} mapper))
 
 (defn post-json-options
-  ([] {:as :stream :timeout 400000 :headers {"Content-Type" mime-application-json}})
-  ([jsession-id] {:as :stream :timeout 400000 :headers {"Content-Type" mime-application-json "Cookie" (str "JSESSIONID=" jsession-id)}}))
+  ([] {:as :stream :timeout 600000 :headers {"Content-Type" mime-application-json}})
+  ([jsession-id] {:as :stream :timeout 600000 :headers {"Content-Type" mime-application-json "Cookie" (str "JSESSIONID=" jsession-id)}}))
 
 (defn post-json-as-channel
   ([url data mapper]


### PR DESCRIPTION
Some very large hakukohtees (thousands of applicants)
could timeout when fetching vastaanottos from vts.