### PR TITLE
A whole bunch of logging related formatting and data omission related bug fixes

### DIFF
--- a/src/ulkoiset_rajapinnat/core.clj
+++ b/src/ulkoiset_rajapinnat/core.clj
@@ -143,7 +143,7 @@
   (init-config args)
   (let [port (-> @config :server :port)]
 
-    (log/info "Starting server in port {}" port)
+    (log/info "Starting server in port" port)
     (let [audit-logger (create-audit-logger)
           server (run-server (api-opintopolku-routes audit-logger) {:port port})
           close-handle (fn [] (-> (meta server)

--- a/src/ulkoiset_rajapinnat/hakemus.clj
+++ b/src/ulkoiset_rajapinnat/hakemus.clj
@@ -285,7 +285,7 @@
                (log/info "Returned successfully" @counter "'hakemusta' from Haku-App and Ataru! Took" (- (System/currentTimeMillis) start-time) "ms!")
                (catch Throwable e
                  (do
-                   (log/error "Failed to write 'hakemukset'!" e)
+                   (log/error e "Failed to write 'hakemukset'!")
                    (write-object-to-channel is-first-written
                                             {:error (.getMessage e)}
                                             channel)
@@ -301,7 +301,7 @@
                               is-illegal-argument (or (instance? IllegalArgumentException e)
                                                       (instance? IllegalArgumentException (.getCause e)))
                               status-code (if is-illegal-argument 400 500)]
-                          (log/error "Exception in fetch-hakemukset-for-haku" e)
+                          (log/error e "Exception in fetch-hakemukset-for-haku")
                           (status channel status-code)
                           (body channel (to-json {:error error-message}))
                           (close channel)

--- a/src/ulkoiset_rajapinnat/haku.clj
+++ b/src/ulkoiset_rajapinnat/haku.clj
@@ -49,7 +49,7 @@
      "haun_kohdejoukon_tarkenne" (get haunkohdejoukontarkenne (strip-version-from-tarjonta-koodisto-uri (haku "kohdejoukonTarkenne")))}))
 
 (defn log-fetch [resource-name start-time response]
-  (log/debug "Fetching '{}' ready with status {}! Took {}ms!" resource-name (response :status) (- (System/currentTimeMillis) start-time))
+  (log/debugf "Fetching '%s' ready with status %s! Took %sms!" resource-name (response :status) (- (System/currentTimeMillis) start-time))
   response)
 
 (defn fetch-haku [vuosi]

--- a/src/ulkoiset_rajapinnat/hakukohde.clj
+++ b/src/ulkoiset_rajapinnat/hakukohde.clj
@@ -14,7 +14,7 @@
             [ulkoiset-rajapinnat.utils.snippets :refer [remove-when remove-nils]]))
 
 (defn log-fetch [resource-name start-time response]
-  (log/debug "Fetching '{}' ready with status {}! Took {}ms!" resource-name (response :status) (- (System/currentTimeMillis) start-time))
+  (log/debugf "Fetching '%s' ready with status %s! Took %sms!" resource-name (response :status) (- (System/currentTimeMillis) start-time))
   response)
 
 (s/defschema Hakukohde
@@ -110,7 +110,7 @@
     (try
       (remove str/blank? (str/split parentOidPath #"\|"))
       (catch Exception e
-        (log/error e (format "Problem when finding parent oids of %s" (pr-str (get organisaatio "oid"))))
+        (log/errorf e "Problem when finding parent oids of %s" (pr-str (get organisaatio "oid")))
         (throw e)))))
 
 (defn get-all-parent-oids [organisaatiot]

--- a/src/ulkoiset_rajapinnat/onr.clj
+++ b/src/ulkoiset_rajapinnat/onr.clj
@@ -12,7 +12,7 @@
 (defn onr-sessionid-channel [] (fetch-jsessionid-channel "/oppijanumerorekisteri-service"))
 
 (defn log-fetch [number-of-oids start-time response]
-  (log/debug "Fetching 'henkilot' (size = {}) ready with status {}! Took {}ms!" number-of-oids (response :status) (- (System/currentTimeMillis) start-time))
+  (log/debugf "Fetching 'henkilot' (size = %s) ready with status %s! Took %sms!" number-of-oids (response :status) (- (System/currentTimeMillis) start-time))
   response)
 
 (defn fetch-henkilot-channel [jsessionid henkilo-oids]

--- a/src/ulkoiset_rajapinnat/utils/config.clj
+++ b/src/ulkoiset_rajapinnat/utils/config.clj
@@ -22,11 +22,11 @@
   [args]
    (if-let [from-args (read-config-path-from-args args)]
     (do
-      (log/info "Using config property {} from main args!" from-args)
+      (log/infof "Using config property %s from main args!" from-args)
       from-args)
     (if-let [from-env (read-config-path-from-env)]
       (do
-        (log/info "Using config property {} from env.vars!" from-env)
+        (log/infof "Using config property %s from env.vars!" from-env)
         from-env)
       (throw (Exception. (str (name ulkoiset-rajapinnat-property-key) " is mandatory! Either give it in args or set env.var!"))))))
 

--- a/src/ulkoiset_rajapinnat/utils/haku_app.clj
+++ b/src/ulkoiset_rajapinnat/utils/haku_app.clj
@@ -80,7 +80,7 @@
                 foo (log/info (str "Haettiin haku-appista " (count hakemus-oids) " oidia"))]
                 (fetch-hakemus-in-batch-channel hakemus-oids hakukohde-oids channel batch-size result-mapper))
           (catch Exception e
-            (log/error e (format "Problem when reading haku-app for haku %s" haku-oid))
+            (log/errorf e "Problem when reading haku-app for haku %s" haku-oid)
             (>! channel e)
             (close! channel)))))
       channel))

--- a/src/ulkoiset_rajapinnat/utils/koodisto.clj
+++ b/src/ulkoiset_rajapinnat/utils/koodisto.clj
@@ -24,7 +24,7 @@
   [(koodisto "koodiUri") (koodisto "koodiArvo")])
 
 (defn- log-fetch [resource-name start-time response]
-  (log/debug "Fetching '{}' ready with status {}! Took {}ms!" resource-name (response :status) (- (System/currentTimeMillis) start-time))
+  (log/debugf "Fetching '%s' ready with status %s! Took %sms!" resource-name (response :status) (- (System/currentTimeMillis) start-time))
   response)
 
 (defn koodisto-as-channel [koodisto]

--- a/src/ulkoiset_rajapinnat/valintaperusteet.clj
+++ b/src/ulkoiset_rajapinnat/valintaperusteet.clj
@@ -137,7 +137,7 @@
                   (body-and-close json))))
           (catch Exception e
             (do
-              (log/error (format "Virhe haettaessa valintaperusteita %d hakukohteelle!" (count requested-oids)), e)
+              (log/errorf e "Virhe haettaessa valintaperusteita %d hakukohteelle!" (count requested-oids))
               (log-to-access-log 500 (.getMessage e))
               ((exception-response channel) e)))))
    (schedule-task (* 1000 60 60) (close channel))))

--- a/src/ulkoiset_rajapinnat/valintapiste.clj
+++ b/src/ulkoiset_rajapinnat/valintapiste.clj
@@ -41,7 +41,7 @@
             (log-to-access-log status-code nil))
           (catch Exception e
             (do
-              (log/error (format "Virhe hakiessa valintapisteitä " haku-oid " " hakukohde-oid) e)
+              (log/errorf e "Virhe hakiessa valintapisteitä " haku-oid " " hakukohde-oid)
               (log-to-access-log 500 (.getMessage e))
               (-> channel
                   (status 500)
@@ -51,7 +51,7 @@
 
 (defn fetch-valintapisteet-for-hakemus-oids [request user channel log-to-access-log]
   (let [hakemus-oids (vec (parse-json-request request))
-        foo (log/info (str "Haetaan hakemus-oidit hakemuksille " hakemus-oids))]
+        _            (log/infof "Haetaan hakemus-oidit hakemuksille %s" hakemus-oids)]
     (if (nil? hakemus-oids)
       (go [])
       (go (try
@@ -61,7 +61,7 @@
                   user-agent  (user-agent-from-request request)
                   url         (resolve-url :valintapiste-service.internal.pisteet-with-hakemusoids jsession-id person-oid inet-addr user-agent)
                   json        (to-json hakemus-oids)
-                  foo         (log/info (str "Post JSON body" json))
+                  _           (log/infof "Post JSON body %s" json)
                   response    (<? (post-as-channel url json (post-json-options jsession-id) nil))
                   status-code (response :status)]
               (-> channel
@@ -70,7 +70,7 @@
               (log-to-access-log status-code nil))
             (catch Exception e
               (do
-                (log/error "Virhe hakiessa valintapisteitä hakemuksille " e)
+                (log/error e "Virhe hakiessa valintapisteitä hakemuksille ")
                 (log-to-access-log 500 (.getMessage e))
                 (-> channel
                     (status 500)


### PR DESCRIPTION
There's roughly three categories of changes in this:
 - exception object needs to be second, not last to get fully logged
 - `(format ...)` was called directly instead of using `logf` macros, this is mostly a stylistic error but inconsistent in any case
 - Logback style `(log/info "some {} logging" parameter)` string substitution replaced with `logf`; these have never worked as intended