### PR TITLE
OY-5429 Vaihdetaan esimerkki käyttämään pnpm:ää

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.iml
 /node_modules
 package-lock.json
+pnpm-lock.yaml
 .DS_Store
 .clj-kondo
 .lsp

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or run Java part only from Idea (Edit Configurations -> Environment Variables ->
 
 ## CAS with Node.js Example
 
-`npm install --save cheerio request bluebird`
+`pnpm install`
 
 `node node_example.js ../file_with_creds_and_host.txt`
 

--- a/node_example.js
+++ b/node_example.js
@@ -29,7 +29,7 @@ postForm(hostname + '/cas/v1/tickets', {username:username, password:password})
 	.then((tgtUrl) => postForm(tgtUrl,{service:hostname+'/ulkoiset-rajapinnat'}))
 	.then((serviceTicket) => {
 //		const url = hostname + '/ulkoiset-rajapinnat/api/hakemus-for-haku-job/1.2.246.562.29.00000000000000021303?ticket=' + serviceTicket
-		const url = hostname + '/ulkoiset-rajapinnat/api/hakemus-for-haku/1.2.246.562.29.00000000000000021303?ticket=' + serviceTicket + '&koulutuksen_alkamisvuosi=2023&koulutuksen_alkamiskausi=kausi_s%231'
+		const url = hostname + '/ulkoiset-rajapinnat/api/hakemus-for-haku/1.2.246.562.29.00000000000000011031?ticket=' + serviceTicket + '&koulutuksen_alkamisvuosi=2023&koulutuksen_alkamiskausi=kausi_s%231'
 		//console.log('Calling URL ' + url)
 		request.get(url, (e,r,body) => {
 			console.log(JSON.stringify(JSON.parse(body), null, 2))

--- a/package.json
+++ b/package.json
@@ -3,5 +3,11 @@
     "bluebird": "^3.7.2",
     "cheerio": "^1.0.0-rc.12",
     "request": "^2.88.2"
+  },
+  "packageManager": "pnpm@10.26.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
+  "scripts": {
+    "preinstall": "pnpx only-allow@1.2.2 pnpm"
+  },
   "dependencies": {
     "bluebird": "^3.7.2",
     "cheerio": "^1.0.0-rc.12",
     "request": "^2.88.2"
   },
-  "packageManager": "pnpm@10.26.0",
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm"
-    }
-  }
+  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
Pakotetaan pnpm:n käyttö, mutta ei edelleenkään lisätä lockfileä versionhallintaan. Täten myöskään frozen-lockfileä ei voi asettaa.

Esimerkkikoodissa vaihdetaan haku sellaiseen, jolla on 9 hakukohdetta tuhansien sijaan, että vastauksen saakin joskus.